### PR TITLE
feat: implement more arithmetic operations

### DIFF
--- a/src/three_dimensional/cylindrical.rs
+++ b/src/three_dimensional/cylindrical.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Display,
-    ops::{Add, Neg, Sub},
+    ops::{Add, Div, Mul, Neg, Sub},
 };
 
 use super::vector3::Vector3;
@@ -194,7 +194,19 @@ impl<T: Float + TrigConsts> Sub for Cylindrical<T> {
     }
 }
 
-impl<T: Float> std::ops::Div<T> for Cylindrical<T> {
+impl<T: Float> Mul<T> for Cylindrical<T> {
+    type Output = Self;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        Self {
+            radius: self.radius * rhs,
+            height: self.height * rhs,
+            azimuth: self.azimuth,
+        }
+    }
+}
+
+impl<T: Float> Div<T> for Cylindrical<T> {
     type Output = Self;
 
     fn div(self, rhs: T) -> Self::Output {

--- a/src/three_dimensional/spherical.rs
+++ b/src/three_dimensional/spherical.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Display,
-    ops::{Add, Neg, Sub},
+    ops::{Add, Div, Mul, Neg, Sub},
 };
 
 use num_traits::Float;
@@ -254,7 +254,19 @@ impl<T: Float> Sub for Spherical<T> {
     }
 }
 
-impl<T: Float> std::ops::Div<T> for Spherical<T> {
+impl<T: Float> Mul<T> for Spherical<T> {
+    type Output = Self;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        Self {
+            radius: self.radius * rhs,
+            azimuthal_angle: self.azimuthal_angle,
+            polar_angle: self.polar_angle,
+        }
+    }
+}
+
+impl<T: Float> Div<T> for Spherical<T> {
     type Output = Self;
 
     fn div(self, rhs: T) -> Self::Output {

--- a/src/three_dimensional/vector3.rs
+++ b/src/three_dimensional/vector3.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Display,
-    ops::{Add, Neg, Sub},
+    ops::{Add, Mul, Neg, Sub},
 };
 
 use num_traits::Float;
@@ -167,6 +167,18 @@ impl<T: Float> std::ops::Div<T> for Vector3<T> {
             x: self.x / rhs,
             y: self.y / rhs,
             z: self.z / rhs,
+        }
+    }
+}
+
+impl<T: Float + Mul + Copy> Mul<T> for Vector3<T> {
+    type Output = Vector3<T>;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        Vector3 {
+            x: self.x * rhs,
+            y: self.y * rhs,
+            z: self.z * rhs,
         }
     }
 }

--- a/src/three_dimensional/vector3.rs
+++ b/src/three_dimensional/vector3.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Add, Mul, Neg, Sub},
 };
 
-use num_traits::Float;
+use num_traits::{CheckedAdd, CheckedSub, Float};
 
 use crate::traits::{Dot, Magnitude, Positional};
 
@@ -180,6 +180,30 @@ impl<T: Float + Mul + Copy> Mul<T> for Vector3<T> {
             y: self.y * rhs,
             z: self.z * rhs,
         }
+    }
+}
+
+/*********************
+ * CHECKED ARITHMETIC TRAITS *
+ *********************/
+
+impl<T: Float + CheckedAdd> CheckedAdd for Vector3<T> {
+    fn checked_add(&self, rhs: &Self) -> Option<Self> {
+        Some(Vector3 {
+            x: self.x.checked_add(&rhs.x)?,
+            y: self.y.checked_add(&rhs.y)?,
+            z: self.z.checked_add(&rhs.z)?,
+        })
+    }
+}
+
+impl<T: Float + CheckedSub> CheckedSub for Vector3<T> {
+    fn checked_sub(&self, rhs: &Self) -> Option<Self> {
+        Some(Vector3 {
+            x: self.x.checked_sub(&rhs.x)?,
+            y: self.y.checked_sub(&rhs.y)?,
+            z: self.z.checked_sub(&rhs.z)?,
+        })
     }
 }
 

--- a/src/two_dimensional/polar.rs
+++ b/src/two_dimensional/polar.rs
@@ -1,4 +1,5 @@
 use num_traits::Float;
+use std::ops::{Add, Div, Mul, Neg, Sub};
 
 use crate::{
     traits::{CrossMagnitude, Dot, Magnitude, Positional, TrigConsts},
@@ -87,7 +88,38 @@ impl<T: Float> Positional<T> for Polar<T> {
     }
 }
 
-impl<T: Float> std::ops::Div<T> for Polar<T> {
+/************************************
+ * ARITHMETIC TRAIT IMPLEMENTATIONS *
+ ************************************/
+
+impl<T: Float + TrigConsts> Add for Polar<T> {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        (Into::<Vector2<T>>::into(self) + Into::<Vector2<T>>::into(rhs)).into()
+    }
+}
+
+impl<T: Float + TrigConsts> Sub for Polar<T> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        (Into::<Vector2<T>>::into(self) - Into::<Vector2<T>>::into(rhs)).into()
+    }
+}
+
+impl<T: Float> Mul<T> for Polar<T> {
+    type Output = Self;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        Self {
+            radius: self.radius * rhs,
+            theta: self.theta,
+        }
+    }
+}
+
+impl<T: Float> Div<T> for Polar<T> {
     type Output = Self;
 
     fn div(self, rhs: T) -> Self::Output {
@@ -97,6 +129,21 @@ impl<T: Float> std::ops::Div<T> for Polar<T> {
         }
     }
 }
+
+impl<T: Float + TrigConsts> Neg for Polar<T> {
+    type Output = Polar<T>;
+
+    fn neg(self) -> Self::Output {
+        Polar {
+            radius: self.radius,
+            theta: (self.theta + T::PI) % T::TAU,
+        }
+    }
+}
+
+/************************
+ * FROM IMPLEMENTATIONS *
+ ************************/
 
 impl<T: Float> From<Vector2<T>> for Polar<T> {
     fn from(cart: Vector2<T>) -> Self {

--- a/src/two_dimensional/vector2.rs
+++ b/src/two_dimensional/vector2.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Add, Mul, Neg, Sub},
 };
 
-use num_traits::{Float, Num};
+use num_traits::{CheckedAdd, CheckedSub, Float, Num};
 
 use crate::traits::TrigConsts;
 
@@ -147,6 +147,28 @@ impl<T: Float> std::ops::Div<T> for Vector2<T> {
             x: self.x / rhs,
             y: self.y / rhs,
         }
+    }
+}
+
+/*********************
+ * CHECKED ARITHMETIC TRAITS *
+ *********************/
+
+impl<T: Num + CheckedAdd> CheckedAdd for Vector2<T> {
+    fn checked_add(&self, rhs: &Self) -> Option<Self> {
+        Some(Vector2 {
+            x: self.x.checked_add(&rhs.x)?,
+            y: self.y.checked_add(&rhs.y)?,
+        })
+    }
+}
+
+impl<T: Num + CheckedSub> CheckedSub for Vector2<T> {
+    fn checked_sub(&self, rhs: &Self) -> Option<Self> {
+        Some(Vector2 {
+            x: self.x.checked_sub(&rhs.x)?,
+            y: self.y.checked_sub(&rhs.y)?,
+        })
     }
 }
 

--- a/src/two_dimensional/vector2.rs
+++ b/src/two_dimensional/vector2.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Display,
-    ops::{Add, Neg, Sub},
+    ops::{Add, Mul, Neg, Sub},
 };
 
 use num_traits::{Float, Num};
@@ -124,6 +124,17 @@ impl<T: Num + Sub> Sub for Vector2<T> {
         Vector2 {
             x: self.x - rhs.x,
             y: self.y - rhs.y,
+        }
+    }
+}
+
+impl<T: Num + Mul + Copy> Mul<T> for Vector2<T> {
+    type Output = Vector2<T>;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        Vector2 {
+            x: self.x * rhs,
+            y: self.y * rhs,
         }
     }
 }


### PR DESCRIPTION
this pull request implements
* arithmetic operations for `Polar`
* scalar-vector multiplication, i.e. `a * (x, y, z) = (ax, ay, az)` for `Vector3` and mutatis mutandis for the other types
* checked addition and subtraction for `Vector2` and `Vector3`. this can be useful if a `Vector2` or Vector3` is used for indexing into nested `Vec`:s. then `u.checked_sub(v)` will check that `u - v` remains in the first quadrant (all components non-negative).